### PR TITLE
Added missing component dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,7 +4,9 @@
   "description": "A small wrapper around crossfilter to make querying simpler",
   "version": "0.0.1",
   "keywords": [],
-  "dependencies": {},
+  "dependencies": {
+    "christopherobin/crossfilter": "*"
+  },
   "development": {},
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Change `christopherobin/crossfilter` to `square/crossfilter` once [square/crossfilter#97](https://github.com/square/crossfilter/pull/97) is in.
